### PR TITLE
 Recursive Check for Nested Removed Nodes in Hyperleaflet

### DIFF
--- a/src/Geometry/hyperleaflet-geometry-handler.js
+++ b/src/Geometry/hyperleaflet-geometry-handler.js
@@ -33,6 +33,9 @@ export default function hyperleafletGeometryHandler(map, { addCallback = () => {
         leafletObject.addTo(map);
         addCallback(node);
       }
+      if (node.childNodes.length > 0) {
+        addNoteListToHyperleaflet(node.childNodes);
+      }
     });
   };
 
@@ -42,6 +45,9 @@ export default function hyperleafletGeometryHandler(map, { addCallback = () => {
         const [leafletObject] = deleteNodeFromHyperleaflet(node);
         leafletObject.remove();
         removeCallback(node);
+      }
+      if (node.childNodes.length > 0) {
+        removeNodeListToHyperleaflet(node.childNodes);
       }
     });
   }

--- a/src/Geometry/index.js
+++ b/src/Geometry/index.js
@@ -11,7 +11,7 @@ function hyperleafletDataToMap(map) {
 
   let callbackFunctions = {};
   if (geometryDisplay === 'json') {
-    const {addToGeometryObject, removeFromGeometryObject } = geometryObjectHandler()
+    const { addToGeometryObject, removeFromGeometryObject } = geometryObjectHandler();
     callbackFunctions = {
       addCallback: addToGeometryObject,
       removeCallback: removeFromGeometryObject,


### PR DESCRIPTION
By introducing the recursive check, we ensure that all nested removed nodes are correctly identified by the Mutation Observer in Hyperleaflet. This fix improves the stability and reliability of the library when dealing with complex DOM structures.

