### PR TITLE
Geometry add-remove mechanism changes

### DIFF
--- a/src/Geometry/index.js
+++ b/src/Geometry/index.js
@@ -1,6 +1,6 @@
 import geometryObjectHandler from './geometry-object-handler';
 import removeGeometryAttributes from './utils';
-import hyperleafletGeometryHandler from './hyperleaflet-geometry-handler';
+import hyperleafletGeometryHandler, { diffNodesWithMap } from './hyperleaflet-geometry-handler';
 
 function hyperleafletDataToMap(map) {
   const hyperleafletDataSource = document.querySelector('[data-hyperleaflet-source]');
@@ -34,12 +34,9 @@ function hyperleafletDataToMap(map) {
   });
 
   function callback(mutations) {
-    mutations.forEach((mutation) => {
-      if (mutation.type === 'childList') {
-        addNoteListToHyperleaflet(mutation.addedNodes);
-        removeNodeListToHyperleaflet(mutation.removedNodes);
-      }
-    });
+    const { addedNodes, removedNodes } = diffNodesWithMap(mutations, map);
+    addNoteListToHyperleaflet(addedNodes);
+    removeNodeListToHyperleaflet(removedNodes);
   }
 
   const observer = new MutationObserver(callback);

--- a/src/Map/map.js
+++ b/src/Map/map.js
@@ -29,7 +29,7 @@ export default function createHyperleafletMap(mapElement) {
   const { center, zoom, minZoom, maxZoom } = mapElement.dataset;
 
   const mapView = {
-    center: center?.split(',').slice().reverse() ?? [0, 0],
+    center: JSON.parse(center).reverse() ?? [0, 0],
     zoom: zoom || 1,
   };
   const leafletMap = map(mapElement, {


### PR DESCRIPTION
This pull request enhances the adding and removing mechanism in Hyperleaflet for better performance and user experience.

The previous mechanism encountered issues with bulk HTML changes and redundant updates. Additionally, continuously adding/removing the same points on the leaflet map caused usability problems.

To tackle these issues, I have made the following enhancements:

    Implemented optimized calculation of "truly" changed geometries using element IDs.
    Utilized a Mutation Observer to track changes and handle additions and removals more efficiently.
    The observer now checks if a removed node is also present in the added nodes and only sends the nodes that are removed but not added.
    Additionally, the observer detects if added nodes are already present in the leaflet map to avoid unnecessary duplicates.

