### PR TITLE
feat: reverse coordinate order all and row based

### DIFF
--- a/src/Geometry/leaflet-geometry.js
+++ b/src/Geometry/leaflet-geometry.js
@@ -3,8 +3,9 @@ import { setPointEvents, setPolyGeometryEvents } from './events';
 import hyperleafletConfig from '../config';
 
 const createPointGeometry = (parsedGeometry, options) => {
-  const { reverse } = options;
-  const geometry = reverse ? [...parsedGeometry].reverse() : parsedGeometry;
+  const { reverse, reverseOrder } = options;
+  const isLonLat = reverse || (reverseOrder !== undefined)
+  const geometry = isLonLat ? [...parsedGeometry].reverse() : parsedGeometry;
   const leafletGeometry = marker(geometry);
   if (options.popup) {
     leafletGeometry.bindPopup(options.popup);
@@ -17,8 +18,9 @@ const createPointGeometry = (parsedGeometry, options) => {
 };
 
 const createLineGeometry = (parsedGeometry, options) => {
-  const { reverse } = options;
-  const geometry = reverse ? GeoJSON.coordsToLatLngs(parsedGeometry, 0) : parsedGeometry;
+  const { reverse, reverseOrder } = options;
+  const isLonLat = reverse || (reverseOrder !== undefined)
+  const geometry = isLonLat ? GeoJSON.coordsToLatLngs(parsedGeometry, 0) : parsedGeometry;
   const leafletGeometry = polyline(geometry);
   if (options.popup) {
     leafletGeometry.bindPopup(options.popup);
@@ -31,8 +33,9 @@ const createLineGeometry = (parsedGeometry, options) => {
 };
 
 const createPolygonGeometry = (parsedGeometry, options) => {
-  const { reverse } = options;
-  const geometry = reverse ? GeoJSON.coordsToLatLngs(parsedGeometry, 1) : parsedGeometry;
+  const { reverse, reverseOrder } = options;
+  const isLonLat = reverse || (reverseOrder !== undefined)
+  const geometry = isLonLat ? GeoJSON.coordsToLatLngs(parsedGeometry, 1) : parsedGeometry;
   const leafletGeometry = polygon(geometry);
   if (options.popup) {
     leafletGeometry.bindPopup(options.popup);
@@ -60,9 +63,9 @@ const createGeometry = (geometryType) => (parsedGeometry, options) => {
 };
 
 export default function createLeafletObject(row) {
-  const { geometry, popup, tooltip, geometryType, id } = row;
+  const { geometry, popup, tooltip, geometryType, id, reverseOrder } = row;
   const parsedGeometry = JSON.parse(geometry);
   const reverse = hyperleafletConfig.reverseCoords;
   const createGeometryFn = createGeometry(geometryType);
-  return createGeometryFn(parsedGeometry, { popup, tooltip, id, reverse });
+  return createGeometryFn(parsedGeometry, { popup, tooltip, id, reverse, reverseOrder });
 }

--- a/src/Geometry/leaflet-geometry.js
+++ b/src/Geometry/leaflet-geometry.js
@@ -3,8 +3,8 @@ import { setPointEvents, setPolyGeometryEvents } from './events';
 import hyperleafletConfig from '../config';
 
 const createPointGeometry = (parsedGeometry, options) => {
-  const { reverse, reverseOrder } = options;
-  const isLonLat = reverse || (reverseOrder !== undefined)
+  const { reverseOrderAll, reverseOrder } = options;
+  const isLonLat = reverseOrderAll || (reverseOrder !== undefined)
   const geometry = isLonLat ? [...parsedGeometry].reverse() : parsedGeometry;
   const leafletGeometry = marker(geometry);
   if (options.popup) {
@@ -18,8 +18,8 @@ const createPointGeometry = (parsedGeometry, options) => {
 };
 
 const createLineGeometry = (parsedGeometry, options) => {
-  const { reverse, reverseOrder } = options;
-  const isLonLat = reverse || (reverseOrder !== undefined)
+  const { reverseOrderAll, reverseOrder } = options;
+  const isLonLat = reverseOrderAll || (reverseOrder !== undefined)
   const geometry = isLonLat ? GeoJSON.coordsToLatLngs(parsedGeometry, 0) : parsedGeometry;
   const leafletGeometry = polyline(geometry);
   if (options.popup) {
@@ -33,8 +33,8 @@ const createLineGeometry = (parsedGeometry, options) => {
 };
 
 const createPolygonGeometry = (parsedGeometry, options) => {
-  const { reverse, reverseOrder } = options;
-  const isLonLat = reverse || (reverseOrder !== undefined)
+  const { reverseOrderAll, reverseOrder } = options;
+  const isLonLat = reverseOrderAll || (reverseOrder !== undefined)
   const geometry = isLonLat ? GeoJSON.coordsToLatLngs(parsedGeometry, 1) : parsedGeometry;
   const leafletGeometry = polygon(geometry);
   if (options.popup) {
@@ -65,7 +65,7 @@ const createGeometry = (geometryType) => (parsedGeometry, options) => {
 export default function createLeafletObject(row) {
   const { geometry, popup, tooltip, geometryType, id, reverseOrder } = row;
   const parsedGeometry = JSON.parse(geometry);
-  const reverse = hyperleafletConfig.reverseCoords;
+  const {reverseOrderAll} = hyperleafletConfig;
   const createGeometryFn = createGeometry(geometryType);
-  return createGeometryFn(parsedGeometry, { popup, tooltip, id, reverse, reverseOrder });
+  return createGeometryFn(parsedGeometry, { popup, tooltip, id, reverseOrderAll, reverseOrder });
 }

--- a/src/Geometry/test/hyperleaflet-geometry-handler.test.js
+++ b/src/Geometry/test/hyperleaflet-geometry-handler.test.js
@@ -6,7 +6,7 @@ import hyperleafletConfig from '../../config';
 
 describe('createLeafletObject', () => {
   beforeEach(() => {
-    hyperleafletConfig.reverseCoords = false;
+    hyperleafletConfig.reverseOrderAll = false;
   });
   it('should create a Leaflet marker object for a point geometry', () => {
     const row = {
@@ -30,7 +30,7 @@ describe('createLeafletObject', () => {
       geometryType: 'Point',
       id: '123',
     };
-    hyperleafletConfig.reverseCoords = true;
+    hyperleafletConfig.reverseOrderAll = true;
     const marker = createLeafletObject(row);
     expect(marker).toBeInstanceOf(L.Marker);
     expect(marker.getLatLng()).toEqual(L.latLng(37.776, -122.414));
@@ -81,5 +81,23 @@ describe('createLeafletObject', () => {
 
     const result = createLeafletObject(row);
     expect(result).toBeNull();
+  });
+
+  it('should create a Leaflet polygon object for a polygon geometry reverse order', () => {
+    const row = {
+      geometry: '[[[-122.414,37.776],[-122.413,37.775],[-122.413,37.776],[-122.414,37.776]]]',
+      popup: 'Hello, world!',
+      tooltip: 'I am a polygon',
+      geometryType: 'Polygon',
+      id: '123',
+      reverseOrder: ""
+    };
+    const polygon = createLeafletObject(row);
+    expect(polygon).toBeInstanceOf(L.Polygon);
+    expect(polygon.getLatLngs()).toEqual([
+      [L.latLng(37.776, -122.414), L.latLng(37.775, -122.413, ), L.latLng( 37.776, -122.413,)],
+    ]);
+    expect(polygon.getPopup().getContent()).toEqual('Hello, world!');
+    expect(polygon.getTooltip().getContent()).toEqual('I am a polygon');
   });
 });

--- a/src/Map/map.js
+++ b/src/Map/map.js
@@ -28,9 +28,9 @@ export function createHyperleafletTiles(tileLayerElementNodeList) {
 
 export default function createHyperleafletMap(mapElement) {
   const { center, zoom, minZoom, maxZoom } = mapElement.dataset;
-  const reverse = hyperleafletConfig.reverseOrderAll;
+  const { reverseOrderAll } = hyperleafletConfig;
   const mapView = {
-    center: safeParsePoint(center, reverse),
+    center: safeParsePoint(center, reverseOrderAll),
     zoom: zoom || 1,
   };
   const leafletMap = map(mapElement, {

--- a/src/Map/map.js
+++ b/src/Map/map.js
@@ -28,7 +28,7 @@ export function createHyperleafletTiles(tileLayerElementNodeList) {
 
 export default function createHyperleafletMap(mapElement) {
   const { center, zoom, minZoom, maxZoom } = mapElement.dataset;
-  const reverse = hyperleafletConfig.reverseCoords;
+  const reverse = hyperleafletConfig.reverseOrderAll;
   const mapView = {
     center: safeParsePoint(center, reverse),
     zoom: zoom || 1,

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
 const hyperleafletConfig = {
-  reverseCoords: false,
+  reverseOrderAll: false,
 };
 export default hyperleafletConfig;


### PR DESCRIPTION
Coordinate order reversing renamed to data-reverse-order-all also row level reverse-order added. This means by default hyperleaflet treat all geometries is in lat lon order but, data-reverse-order* attributes changes them to lon lat.