### PR TITLE
Wire up polyline options for polygon using data-options

### DIFF
--- a/src/Geometry/leaflet-geometry.js
+++ b/src/Geometry/leaflet-geometry.js
@@ -49,10 +49,10 @@ function changeLineGeometry(leafletObject, parsedGeometry, options) {
 }
 
 const createPolygonGeometry = (parsedGeometry, options) => {
-  const { reverseOrderAll, reverseOrder } = options;
+  const { reverseOrderAll, reverseOrder, options: polylineOptions } = options;
   const isLonLat = reverseOrderAll || reverseOrder !== undefined;
   const geometry = isLonLat ? GeoJSON.coordsToLatLngs(parsedGeometry, 1) : parsedGeometry;
-  const leafletGeometry = polygon(geometry);
+  const leafletGeometry = polygon(geometry, polylineOptions);
   if (options.popup) {
     leafletGeometry.bindPopup(options.popup);
   }
@@ -106,11 +106,19 @@ function changeGeometry(leafletObject, change) {
 }
 
 export function createLeafletObject(dataset) {
-  const { geometry, popup, tooltip, geometryType, id, reverseOrder } = dataset;
+  const { geometry, popup, tooltip, geometryType, id, reverseOrder, options = '{}' } = dataset;
   const parsedGeometry = JSON.parse(geometry);
+  const parsedOptions = JSON.parse(options);
   const { reverseOrderAll } = hyperleafletConfig;
   const createGeometryFn = createGeometry(geometryType);
-  return createGeometryFn(parsedGeometry, { popup, tooltip, id, reverseOrderAll, reverseOrder });
+  return createGeometryFn(parsedGeometry, {
+    popup,
+    tooltip,
+    id,
+    reverseOrderAll,
+    reverseOrder,
+    options: parsedOptions,
+  });
 }
 
 export function changeLeafletObject(leafletObject, change) {

--- a/src/Geometry/test/geometry-object-handler.test.js
+++ b/src/Geometry/test/geometry-object-handler.test.js
@@ -79,7 +79,11 @@ describe('geometryObjectHandler', () => {
       },
       '2': {
         type: 'LineString',
-        coordinates: [[1, 2], [3, 4], [5, 6]],
+        coordinates: [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+        ],
       },
     });
   });

--- a/src/Geometry/test/hyperleaflet-geometry-handler.test.js
+++ b/src/Geometry/test/hyperleaflet-geometry-handler.test.js
@@ -121,4 +121,20 @@ describe('createLeafletObject', () => {
     expect(polygon.getPopup().getContent()).toEqual('Hello, world!');
     expect(polygon.getTooltip().getContent()).toEqual('I am a polygon');
   });
+
+  it('should create a Leaflet polygon object with polyline options', () => {
+    const row = {
+      geometry: '[[[-122.414,37.776],[-122.413,37.775],[-122.413,37.776],[-122.414,37.776]]]',
+      geometryType: 'Polygon',
+      id: '123',
+      reverseOrder: '',
+      options: '{"color": "blue"}',
+    };
+    const polygon = createLeafletObject(row);
+    expect(polygon).toBeInstanceOf(L.Polygon);
+    expect(polygon.options).toEqual({ color: 'blue' });
+    expect(polygon.getLatLngs()).toEqual([
+      [L.latLng(37.776, -122.414), L.latLng(37.775, -122.413), L.latLng(37.776, -122.413)],
+    ]);
+  });
 });


### PR DESCRIPTION
Add support for second positional argument to `L.polygon` via the `data-options` attribute.